### PR TITLE
Fix missing base slug

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ collections:
   authors:
     output: true
     
-baseurl: https://yardasol.github.io/gxctfaa
+baseurl: /gxctfaa
 
 defaults:
   - scope:

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,5 +1,5 @@
 <nav>
   {% for item in site.data.navigation %}
-    <a href="{{ item.link }}" {% if page.url == item.link %}class="current"{% endif %}>{{ item.name }}</a>
+  <a href="{{ site.baseurl }}{{ item.link }}" {% if page.url == item.link %}class="current"{% endif %}>{{ item.name }}</a>
   {% endfor %}
 </nav>

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -10,6 +10,6 @@ layout: default
 <ul>
   {% assign filtered_posts = site.posts | where: 'author', page.short_name %}
   {% for post in filtered_posts %}
-    <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+  <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></li>
   {% endfor %}
 </ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>{{ page.title }}</title>
-    <link rel="stylesheet" href="{{ site.baseurl  }}/assets/css/styles.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/styles.css">
   </head>
   <body>
 					{% include navigation.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>{{ page.title }}</title>
-		<link rel="stylesheet" href="/assets/css/styles.css">
+    <link rel="stylesheet" href="{{ site.baseurl  }}/assets/css/styles.css">
   </head>
   <body>
 					{% include navigation.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
   {{ page.date | date_to_string }}
   {% assign author = site.authors | where: 'short_name', page.author | first %}
   {% if author %}
-    - <a href="{{ author.url }}">{{ author.name }}</a>
+  - <a href="{{ site.baseurl }}{{ author.url }}">{{ author.name }}</a>
   {% endif %}
 </p>
 

--- a/archives.md
+++ b/archives.md
@@ -2,5 +2,5 @@
 layout: default 
 ---
 
-[Locker Room Jukebox](/archives/jukebox.html)
+[Locker Room Jukebox]( {{ site.baseurl }}/archives/jukebox.html)
 

--- a/news.md
+++ b/news.md
@@ -2,7 +2,7 @@
 title: News
 ---
 
-{% for post in site.posts %}* ## [{{ post.date | date_to_string }} - {{ post.title }}]({{ post.url }})
+{% for post in site.posts %}* ## [{{ post.date | date_to_string }} - {{ post.title }}]({{ site.baseurl }}{{ post.url }})
     
     {{ post.excerpt }}
 {% endfor %}


### PR DESCRIPTION
- change baseurl to /gxctfaa
- adde {{ site.baseurl }} to links

## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting -->
This PR fixes the missing `/gxctfaa` slug as described in issue #7.

I used the fix described [here](https://github.com/jekyll/jekyll/issues/332#issuecomment-18952908) to fix the problem.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Required for Merging
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] I have tested the website build

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request -->

- Issue: #7



## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the 
Review Checklist before they begin their review.
